### PR TITLE
Adding clear function and removing delay from fill

### DIFF
--- a/neopixel.py
+++ b/neopixel.py
@@ -197,4 +197,7 @@ class Neopixel:
     def fill(self, rgb_w, how_bright = None):
         for i in range(self.num_leds):
             self.set_pixel(i, rgb_w, how_bright)
-        time.sleep(self.delay)
+
+    # Clear the strip
+    def clear(self):
+        self.pixels = array.array("I", [0 for _ in range(self.num_leds)])


### PR DESCRIPTION
As per https://github.com/blaz-r/pi_pico_neopixel/issues/4

- Removing unnecessary sleep from `fill()`
- Adding `clear()` function to reset the strip
