### PR TITLE
Add 'assign to slice'  (__setitem__) method, plus various speed improvements

### DIFF
--- a/examples/set_range.py
+++ b/examples/set_range.py
@@ -1,0 +1,40 @@
+# Example showing use of 'slice setting'
+import time
+from neopixel import Neopixel
+
+
+numpix = 60
+K = 3
+
+strip = Neopixel(numpix, 0, 0, "GRB")
+red = (255, 0, 0)
+green = (0, 255, 0)
+blue = (0, 0, 255)
+
+# set the first K to red, next K to green, next K to blue;
+# and the rest to R,G,B,R,B  ... and then spin it.
+
+# reduce K, if numpix is < K*3+1
+K = min(K,(numpix-1)//3)
+
+strip.brightness(80)
+
+strip[:] = blue   # all to blue first...
+# now fill in the red & green...
+strip[:K] = red
+strip[K:2*K] = green
+strip[3*K::3] = red
+strip[3*K+1::3] = green
+
+strip.show()
+
+# show it for 5 seconds...
+time.sleep(5.0)
+
+# spin it...
+
+while(True):
+    strip.rotate_right()
+    strip.show()
+    time.sleep(0.5)
+

--- a/neopixel.py
+++ b/neopixel.py
@@ -49,8 +49,9 @@ def sk6812():
 class Neopixel:
     def __init__(self, num_leds, state_machine, pin, mode="RGB", delay=0.0001):
         self.pixels = array.array("I", [0 for _ in range(num_leds)])
-        self.mode = set(mode)   # set for better performance
-        if 'W' in self.mode:
+        self.mode = mode
+        self.W_in_mode = 'W' in mode
+        if self.W_in_mode:
             # RGBW uses different PIO state machine configuration
             self.sm = rp2.StateMachine(state_machine, sk6812, freq=8000000, sideset_base=Pin(pin))
             # dictionary of values required to shift bit into position (check class desc.)
@@ -90,7 +91,7 @@ class Neopixel:
             green = round((right_rgb_w[1] - left_rgb_w[1]) * fraction + left_rgb_w[1])
             blue = round((right_rgb_w[2] - left_rgb_w[2]) * fraction + left_rgb_w[2])
             # if it's (r, g, b, w)
-            if len(left_rgb_w) == 4 and 'W' in self.mode:
+            if len(left_rgb_w) == 4 and self.W_in_mode:
                 white = round((right_rgb_w[3] - left_rgb_w[3]) * fraction + left_rgb_w[3])
                 self.set_pixel(left_pixel + i, (red, green, blue, white), how_bright)
             else:
@@ -115,7 +116,7 @@ class Neopixel:
         blue = round(rgb_w[2] * bratio)
         white = 0
         # if it's (r, g, b, w)
-        if len(rgb_w) == 4 and 'W' in self.mode:
+        if len(rgb_w) == 4 and self.W_in_mode:
             white = round(rgb_w[3] * bratio)
 
         self.pixels[pixel_num] = white << pos['W'] | blue << pos['B'] | red << pos['R'] | green << pos['G']
@@ -187,7 +188,7 @@ class Neopixel:
     def show(self):
         # If mode is RGB, we cut 8 bits of, otherwise we keep all 32
         cut = 8
-        if 'W' in self.mode:
+        if self.W_in_mode:
             cut = 0
         for i in range(self.num_leds):
             self.sm.put(self.pixels[i], cut)

--- a/neopixel.py
+++ b/neopixel.py
@@ -67,7 +67,7 @@ class Neopixel:
 
     # Set the overal value to adjust brightness when updating leds
     def brightness(self, brightness=None):
-        if brightness == None:
+        if brightness is None:
             return self.brightnessvalue
         else:
             if brightness < 1:
@@ -105,7 +105,7 @@ class Neopixel:
     # Set red, green and blue value of pixel on position <pixel_num>
     # Function accepts (r, g, b) / (r, g, b, w) tuple
     def set_pixel(self, pixel_num, rgb_w, how_bright = None):
-        if how_bright == None:
+        if how_bright is None:
             how_bright = self.brightness()
         pos = self.shift
 
@@ -170,14 +170,14 @@ class Neopixel:
 
 
     # Rotate <num_of_pixels> pixels to the left
-    def rotate_left(self, num_of_pixels):
-        if num_of_pixels == None:
+    def rotate_left(self, num_of_pixels = None):
+        if num_of_pixels is None:
             num_of_pixels = 1
         self.pixels = self.pixels[num_of_pixels:] + self.pixels[:num_of_pixels]
 
     # Rotate <num_of_pixels> pixels to the right
-    def rotate_right(self, num_of_pixels):
-        if num_of_pixels == None:
+    def rotate_right(self, num_of_pixels = None):
+        if num_of_pixels is None:
             num_of_pixels = 1
         num_of_pixels = -1 * num_of_pixels
         self.pixels = self.pixels[num_of_pixels:] + self.pixels[:num_of_pixels]

--- a/neopixel.py
+++ b/neopixel.py
@@ -108,14 +108,15 @@ class Neopixel:
         if how_bright is None:
             how_bright = self.brightness()
         pos = self.shift
+        bratio = how_bright / 255.0
 
-        red = round(rgb_w[0] * (how_bright / 255))
-        green = round(rgb_w[1] * (how_bright / 255))
-        blue = round(rgb_w[2] * (how_bright / 255))
+        red = round(rgb_w[0] * bratio)
+        green = round(rgb_w[1] * bratio)
+        blue = round(rgb_w[2] * bratio)
         white = 0
         # if it's (r, g, b, w)
         if len(rgb_w) == 4 and 'W' in self.mode:
-            white = round(rgb_w[3] * (how_bright / 255))
+            white = round(rgb_w[3] * bratio)
 
         self.pixels[pixel_num] = white << pos['W'] | blue << pos['B'] | red << pos['R'] | green << pos['G']
 

--- a/neopixel.py
+++ b/neopixel.py
@@ -68,7 +68,7 @@ class Neopixel:
     #]
 
     def __init__(self, num_leds, state_machine, pin, mode="RGB", delay=0.0001):
-        self.pixels = array.array("I", [0 for _ in range(num_leds)])
+        self.pixels = array.array("I", [0] * num_leds)
         self.mode = mode
         self.W_in_mode = 'W' in mode
         if self.W_in_mode:
@@ -248,4 +248,5 @@ class Neopixel:
 
     # Clear the strip
     def clear(self):
-        self.pixels = array.array("I", [0 for _ in range(self.num_leds)])
+        self.pixels = array.array("I", [0] * self.num_leds)
+

--- a/neopixel.py
+++ b/neopixel.py
@@ -105,14 +105,21 @@ class Neopixel:
         right_pixel = max(pixel1, pixel2)
         left_pixel = min(pixel1, pixel2)
 
+        with_W = len(left_rgb_w) == 4 and self.W_in_mode
+        r_diff = right_rgb_w[0] - left_rgb_w[0]
+        g_diff = right_rgb_w[1] - left_rgb_w[1]
+        b_diff = right_rgb_w[2] - left_rgb_w[2]
+        if with_W:
+            w_diff = (right_rgb_w[3] - left_rgb_w[3])
+
         for i in range(right_pixel - left_pixel + 1):
             fraction = i / (right_pixel - left_pixel)
-            red = round((right_rgb_w[0] - left_rgb_w[0]) * fraction + left_rgb_w[0])
-            green = round((right_rgb_w[1] - left_rgb_w[1]) * fraction + left_rgb_w[1])
-            blue = round((right_rgb_w[2] - left_rgb_w[2]) * fraction + left_rgb_w[2])
+            red = round(r_diff * fraction + left_rgb_w[0])
+            green = round(g_diff * fraction + left_rgb_w[1])
+            blue = round(b_diff * fraction + left_rgb_w[2])
             # if it's (r, g, b, w)
-            if len(left_rgb_w) == 4 and self.W_in_mode:
-                white = round((right_rgb_w[3] - left_rgb_w[3]) * fraction + left_rgb_w[3])
+            if with_W:
+                white = round(w_diff * fraction + left_rgb_w[3])
                 self.set_pixel(left_pixel + i, (red, green, blue, white), how_bright)
             else:
                 self.set_pixel(left_pixel + i, (red, green, blue), how_bright)

--- a/neopixel.py
+++ b/neopixel.py
@@ -236,8 +236,9 @@ class Neopixel:
         cut = 8
         if self.W_in_mode:
             cut = 0
-        for i in range(self.num_leds):
-            self.sm.put(self.pixels[i], cut)
+        sm_put = self.sm.put
+        for pixval in self.pixels:
+            sm_put(pixval, cut)
         time.sleep(self.delay)
 
     # Set all pixels to given rgb values

--- a/neopixel.py
+++ b/neopixel.py
@@ -47,6 +47,19 @@ def sk6812():
 # Same hold for every other index (and - 1 at the end for 3 letter strings).
 
 class Neopixel:
+    # Micropython doesn't implement __slots__, but it's good to have a place
+    # to describe the data members...
+    #__slots__ = [
+    #    'num_leds',   # number of LEDs
+    #    'pixels',     # array.array('I') of raw data for LEDs
+    #    'mode',       # mode 'RGB' etc
+    #    'W_in_mode',  # bool: is 'W' in mode
+    #    'sm',         # state machine
+    #    'shift',      # shift amount for each component : { 'R': shift_R, ... }
+    #    'delay',      # delay amount
+    #    'brightnessvalue', # brightness scale factor 1..255
+    #]
+
     def __init__(self, num_leds, state_machine, pin, mode="RGB", delay=0.0001):
         self.pixels = array.array("I", [0 for _ in range(num_leds)])
         self.mode = mode


### PR DESCRIPTION
This is a mostly a number of small changes to improve efficiency; and there are two 'feature adds':
  - you can now assign to a slice, e.g. `pixels[:12:2] = red`,  see `examples/set_range.py`
  - `rotate_left()` and `rotate_right()` can now be called with no parameter; defaults to 1 (this looks like it was the original intent)

I had looked for a way to pass a range of pixels to `set_pixel`, so that when calling `set_pixel_line` or `fill`, we could avoid the repeated calculation inside `set_pixel`; instead, just do it it once and store it multiple times. By making `set_pixel` accept a slice object for 'pixel_num', we get this advantage and can also implement the `__setitem__` operation for assigning to slices, by just forwarding the slice to `get_pixel`.

The branch is a series of small, mostly independent mods (one per commit) to make it easier to review; and relatively easy to drop any you don't like.

NOTE: I have only tested with `"GRB"` mode, since that's what the LEDs I have are.